### PR TITLE
Add Markdown linter in container and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
         run: ansible-lint playbooks/*.yml
       - name: Check project yamls
         run: yamllint -s projects/${KPA_PROJECT}/*.yml
+      - name: Check markdown files for example project
+        run: mdl projects/${KPA_PROJECT}/contents/*.md
 
   markdown:
     runs-on: ubuntu-latest

--- a/.mdl.rb
+++ b/.mdl.rb
@@ -1,0 +1,3 @@
+all
+rule 'MD013', :code_blocks => false, :ignore_code_blocks => true, :tables => false
+exclude_rule 'MD033'

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "#{File.dirname(__FILE__)}/.mdl.rb"

--- a/CI.md
+++ b/CI.md
@@ -38,6 +38,8 @@ jobs:
         run: ln -vs ${GITHUB_WORKSPACE} /kpa/projects/${KPA_PROJECT}
       - name: Check project yamls
         run: yamllint -s projects/${KPA_PROJECT}/*.yml
+      - name: Check markdown files for example project                          
+        run: mdl projects/${KPA_PROJECT}/contents/*.md
 
   markdown:
     runs-on: ubuntu-latest
@@ -132,6 +134,8 @@ lint:
   script:
     # YAML check
     - yamllint -s *.yml
+    # Markdown check
+    - mdl contents/*.md
 
 markdown:
   stage: markdown

--- a/Containerfile
+++ b/Containerfile
@@ -3,16 +3,22 @@ FROM quay.io/ansible/ansible-core
 
 WORKDIR /kpa
 
-# YAMLLINT
+# Install yamllint
 RUN pip3 install yamllint ansible-lint
 
-# KPA
+# Install mdl (Mardownlinter)
+RUN dnf -y module reset ruby
+RUN dnf -y module enable ruby:2.7
+RUN dnf -y install rubygems
+RUN gem install mdl
+
+# Install Marp
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -
+RUN dnf -y --enablerepo epel install chromium nodejs
+RUN npm install -g @marp-team/marp-cli
+
+# Install KPA repository
 RUN git clone https://github.com/mmul-it/kpa .
 RUN ansible-galaxy install \
       -r playbooks/roles/requirements.yml \
       --roles-path ./playbooks/roles
-
-# Marp
-RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -
-RUN dnf -y --enablerepo epel install chromium nodejs
-RUN npm install -g @marp-team/marp-cli


### PR DESCRIPTION
This commit adds the ability for the generated container to do markdown files linter check using mdl.
It also changes the GitHub actions process to include markdown linter processing the example project.