### PR TITLE
Use kpa-marp-pandoc:v1.2.0 as base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for KPA project to be used in CI
 
 # Start from kpa-marp-pandoc
-FROM ghcr.io/mmul-it/kpa-marp-pandoc:v1.1.0
+FROM ghcr.io/mmul-it/kpa-marp-pandoc:v1.2.0
 
 # Create workdir path
 RUN mkdir /kpa


### PR DESCRIPTION
The v1.2.0 container fixed the versions for the releases of the Debian base container, NodeJS and Marp.
In this way it will be much simpler to understand which releases are used by a KPA version.

Fixes: #18